### PR TITLE
BE API 수정 및 새로운 스키마 작성, 수정

### DIFF
--- a/pages/api/auth/kakao.js
+++ b/pages/api/auth/kakao.js
@@ -13,11 +13,19 @@ export default async function handler(req, res) {
       if (!user) {
         // db에 유저 없을경우 생성
         console.log("새로운 유저 업데이트");
-        user = new User({ id, name: nickname, profileImage: profile_image, age });
+        user = new User({
+          id,
+          name: nickname,
+          profileImage: profile_image,
+          age: 20, // 카카오에서 나이를 받을려면 사업자를 내야함; 그래서 일딴 20살로 고정적으로 주게 설정함
+          gender: "중성", //이것 또한 카카오에서 기본적으로 제공해주질 않음 ㅠㅠ
+        });
         await user.save();
       }
       // 확인 후 유저 토큰 발행
-      const token = jwt.sign({ userId: user.id }, process.env.JWT_SECRET, { expiresIn: "1h" });
+      const token = jwt.sign({ userId: user.id }, process.env.JWT_SECRET, {
+        expiresIn: "1h",
+      });
 
       console.log(user, token);
       // 토큰 발행 후 토큰 전송

--- a/pages/api/lib/models/user.model.js
+++ b/pages/api/lib/models/user.model.js
@@ -6,6 +6,7 @@ const userSchema = new mongoose.Schema(
     age: { type: Number, required: true },
     name: { type: String, required: true, maxlength: 10 },
     about: { type: String, default: "", maxlength: 30 },
+    gender: { type: String },
     profileImage: { type: String },
     posts: [{ type: mongoose.Schema.Types.ObjectId, ref: "Post" }],
     rating: { type: Number, default: 0 },

--- a/pages/api/lib/models/write.model.js
+++ b/pages/api/lib/models/write.model.js
@@ -7,20 +7,22 @@ const writeSchema = new mongoose.Schema(
     image: [String],
     dateSelectData: {
       startDate: Date,
-      endDate: Date
+      endDate: Date,
     },
     genderAgeSelectData: {
       gender: String,
-      ageRange: String
+      ageRange: String,
     },
     headSelectData: {
-      headCounts: String
+      headCounts: String,
     },
-    travelMapData: { /* 여행지도 구조 정의 */ },
+    travelMapData: {
+      /* 여행지도 구조 정의 */
+    },
+  },
   {
     timestamps: true,
   }
-}
 );
 
 export default mongoose.models.Write || mongoose.model("Write", writeSchema);

--- a/pages/api/logined.js
+++ b/pages/api/logined.js
@@ -11,10 +11,19 @@ export default async function logined(req, res) {
     }
     console.log(decoded, "디코딩정보임");
 
-    const user = await User.findOne({ id: decoded.userId }).select("profileImage name -_id");
+    const user = await User.findOne({ id: decoded.userId }).select(
+      "profileImage name age about id gender -_id"
+    );
     // 이미지, 이름 반환 + 고유 아이디 반환 X
     console.log("성공!", user);
-    return res.status(200).json({ profileImage: user.profileImage });
+    return res.status(200).json({
+      id: user.id,
+      profileImage: user.profileImage,
+      age: user.age,
+      name: user.name,
+      about: user.about,
+      gender: user.gender,
+    });
   } else {
     console.log("실패~");
     res.status(405).end();

--- a/pages/api/logined.js
+++ b/pages/api/logined.js
@@ -1,0 +1,22 @@
+import verifyToken from "./utils/verifyToken";
+import User from "./lib/models/user.model";
+
+export default async function logined(req, res) {
+  if (req.method === "GET") {
+    // 토큰 검증
+    const decoded = verifyToken(req);
+    if (!decoded) {
+      console.log("무언가에서 실패해버림");
+      return res.status(401).json({ error: "인증 실패" });
+    }
+    console.log(decoded, "디코딩정보임");
+
+    const user = await User.findOne({ id: decoded.userId }).select("profileImage name -_id");
+    // 이미지, 이름 반환 + 고유 아이디 반환 X
+    console.log("성공!", user);
+    return res.status(200).json({ profileImage: user.profileImage });
+  } else {
+    console.log("실패~");
+    res.status(405).end();
+  }
+}


### PR DESCRIPTION
1. 카카오 로그인 api 수정
    카카오 로그인 api 호출시 던져주는 정보중 gender 추가, age를 정적으로 던져주도록 설정 [이유는 주석]
2. 게시글 작성 스키마 작성
3. 유저 스키마에 성별[gender]추가
4. 로그인 검증 api에 던져주는 정보 추가 : 원본은 프로필 이미지만 -> 업데이트본은 id, age, image, about, gender  5가지정보 모두 던져줌 [ 임시적으로 바쁘니 그냥 다던져주고 프로필 로드시 그냥 흩뿌리겠음 나중에 수정해야함 ]
