### PR TITLE
refactor: 탑바를 컴포넌트에서 로드하면 안돼요

### DIFF
--- a/components/notification/Notifications.js
+++ b/components/notification/Notifications.js
@@ -1,6 +1,4 @@
 import React, { useState, useEffect } from "react";
-import Topbar from "../topbar/TopBar";
-import BackBtn from "../topbar/BackButton";
 import styles from "./Notifications.module.css";
 
 const Notifications = () => {
@@ -36,8 +34,6 @@ const Notifications = () => {
 
   return (
     <div className={styles.notificationsContainer}>
-      <Topbar leftContent={<BackBtn />} middleContent={"알림"} />
-
       <div className={styles.notificationList}>
         {notifications.map((notification) => (
           <React.Fragment key={notification.id}>
@@ -45,8 +41,7 @@ const Notifications = () => {
               <div className={styles.notification}>{notification.content}</div>
               <div className={styles.smallText}>10시간 전</div>
             </div>
-            <hr className={styles.divider} />{" "}
-            {/* 각 알림 아이템 아래에 구분선 추가 */}
+            <hr className={styles.divider} /> {/* 각 알림 아이템 아래에 구분선 추가 */}
           </React.Fragment>
         ))}
       </div>


### PR DESCRIPTION
pages의 파일에서 컴포넌트의 역할은 전반적인 코드의 흐름을 간략하게 나타냅니다
하나의 파일에 다 넣어버리면 흐름을 못보죠 ..